### PR TITLE
Apply TransformReferenceId to URL/URI nodes in CryptoHashProcessor

### DIFF
--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Processors/CryptoHashProcessorTests.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Processors/CryptoHashProcessorTests.cs
@@ -24,6 +24,18 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Processors
             yield return new object[] { new FhirDateTime("2017-01-01T00:00:00.000Z"), "4c765fc04a6f9967d493ff39238d47993c709d3392a72060efeff285cf7b2501" };
         }
 
+        public static IEnumerable<object[]> GetUrlNodesForCryptoHash()
+        {
+            yield return new object[] { new FhirUrl(string.Empty), string.Empty };
+            yield return new object[] { new FhirUrl("Binary/emNcu.QDEFoP0dFgj"), "Binary/4ec4b2eecdc9585039c3bc2cbd11075ed2b8edaf6598bc3ca91933b3b95af104" };
+            yield return new object[] { new FhirUrl("Patient/example"), "Patient/698d54f0494528a759f19c8e87a9f99e75a5881b9267ee3926bcf62c992d84ba" };
+            yield return new object[] { new FhirUrl("http://example.org/fhir/Observation/apo89654/_history/2"),
+                "http://example.org/fhir/Observation/b1e85ca33baf76575ad28588af85b8f10c0dd40e9ed8cd57cdb7ae94ccd75695/_history/2" };
+            yield return new object[] { new FhirUrl("http://example.com/nonreference"), "892d091b2aed25b51381757541a5a853b9857ba7807b9a448142cc8f1b61df69" };
+            yield return new object[] { new FhirUri("Patient/example"), "Patient/698d54f0494528a759f19c8e87a9f99e75a5881b9267ee3926bcf62c992d84ba" };
+            yield return new object[] { new FhirUri("http://example.com/nonreference"), "892d091b2aed25b51381757541a5a853b9857ba7807b9a448142cc8f1b61df69" };
+        }
+
         public static IEnumerable<object[]> GetReferenceNodesForCryptoHash()
         {
             yield return new object[] { new ResourceReference(string.Empty), string.Empty };
@@ -43,6 +55,16 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Processors
         [Theory]
         [MemberData(nameof(GetNonReferenceNodesForCryptoHash))]
         public void GivenANonReferenceNode_WhenCryptoHash_HashedNodeShouldBeReturned(Element element, string expectedValue)
+        {
+            var processor = new CryptoHashProcessor(TestHashKey);
+            var node = CreateNodeFromElement(element);
+            processor.Process(node);
+            Assert.Equal(expectedValue, node.Value);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetUrlNodesForCryptoHash))]
+        public void GivenAUrlNode_WhenCryptoHash_PartlyHashedNodeShouldBeReturned(Element element, string expectedValue)
         {
             var processor = new CryptoHashProcessor(TestHashKey);
             var node = CreateNodeFromElement(element);

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/Constants.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/Constants.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core
         internal const string AgeTypeName = "Age";
         internal const string BundleTypeName = "Bundle";
         internal const string ReferenceTypeName = "Reference";
+        internal const string UrlTypeName = "url";
+        internal const string UriTypeName = "uri";
 
         // NodeName constants
         internal const string PostalCodeNodeName = "postalCode";

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/Extensions/TypedElementExtensions.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/Extensions/TypedElementExtensions.cs
@@ -41,6 +41,13 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.Extensions
             return node != null && string.Equals(node.InstanceType, Constants.ReferenceTypeName, StringComparison.InvariantCultureIgnoreCase);
         }
 
+        public static bool IsUrlNode(this ITypedElement node)
+        {
+            return node != null &&
+                   (string.Equals(node.InstanceType, Constants.UrlTypeName, StringComparison.InvariantCultureIgnoreCase) ||
+                    string.Equals(node.InstanceType, Constants.UriTypeName, StringComparison.InvariantCultureIgnoreCase));
+        }
+
         public static bool IsPostalCodeNode(this ITypedElement node)
         {
             return node != null && string.Equals(node.Name, Constants.PostalCodeNodeName, StringComparison.InvariantCultureIgnoreCase);

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/Processors/CryptoHashProcessor.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/Processors/CryptoHashProcessor.cs
@@ -29,8 +29,9 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.Processors
             }
 
             var input = node.Value.ToString();
-            // Hash the id part for "Reference.reference" node and hash whole input for other node types
-            if (node.IsReferenceStringNode())
+            // Hash the id part for "Reference.reference" and URL/URI nodes (which may contain relative references),
+            // and hash whole input for other node types
+            if (node.IsReferenceStringNode() || node.IsUrlNode())
             {
                 var newReference = ReferenceUtility.TransformReferenceId(input, _cryptoHashFunction);
                 node.Value = newReference;


### PR DESCRIPTION
URL and URI nodes can contain relative resource references (e.g. "Binary/emNcu.QDEFoP0dFgj") that should have only the ID portion hashed, preserving the resource type prefix. This extends the same reference-aware hashing already used for Reference.reference nodes.